### PR TITLE
문제 1: 동시 예약 문제 해결하기

### DIFF
--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
@@ -26,4 +26,7 @@ class ReservationCacheService {
         cache.remove(key)
     }
 
+    fun clearAll(){
+        cache.clear()
+    }
 }

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
@@ -1,0 +1,29 @@
+package com.minturtle.cs.problem1.service
+
+import com.minturtle.cs.problem1.entity.Reservation
+import org.springframework.stereotype.Component
+import java.util.concurrent.ConcurrentHashMap
+
+
+@Component
+class ReservationCacheService {
+
+    private val cache : MutableMap<String, Reservation> = ConcurrentHashMap()
+
+    fun add(key: String, entity: Reservation): Boolean{
+        return cache.putIfAbsent(key, entity)?.let{ false } ?: true
+    }
+
+    fun getAll(): Collection<Reservation>{
+        return cache.values
+    }
+
+    fun get(key: String): Reservation?{
+        return cache[key]
+    }
+
+    fun remove(key: String){
+        cache.remove(key)
+    }
+
+}

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -4,7 +4,6 @@ import com.minturtle.cs.problem1.entity.Reservation
 import com.minturtle.cs.problem1.repository.ReservationRepository
 import org.springframework.stereotype.Service
 import java.lang.RuntimeException
-import java.util.concurrent.atomic.AtomicInteger
 
 
 @Service

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -9,19 +9,42 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @Service
 class ReservationService(
-    private val reservationRepository: ReservationRepository
+    private val reservationRepository: ReservationRepository,
+    private val cache: ReservationCacheService
 ) {
     private val idSeq = AtomicInteger(0)
 
-    fun save(entity: Reservation){
-        reservationRepository.save(idSeq.addAndGet(1).toLong(), entity)
+    companion object{
+        private val RESERVATION_CACHE_PREFIX = "RESERVATION_"
     }
+
+    fun save(entity: Reservation){
+        val key = RESERVATION_CACHE_PREFIX + entity.hashCode()
+
+        if (reservationRepository.findAll().contains(entity)){
+            throw RuntimeException()
+        }
+        if(cache.add(key, entity)){
+            return
+        }
+        throw RuntimeException()
+    }
+
+    fun toPermanent(entity: Reservation){
+        val key = RESERVATION_CACHE_PREFIX + entity.hashCode()
+        val cacheValue = cache.get(key) ?: throw RuntimeException()
+
+        reservationRepository.save(idSeq.incrementAndGet().toLong(), cacheValue)
+        cache.remove(key)
+    }
+
+
 
     fun findById(id : Long): Reservation {
         return reservationRepository.findById(id) ?: throw RuntimeException()
     }
 
     fun findAll(): Collection<Reservation> {
-        return reservationRepository.findAll()
+        return reservationRepository.findAll() + cache.getAll()
     }
 }

--- a/src/test/kotlin/com/minturtle/cs/problem1/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/minturtle/cs/problem1/ReservationServiceTest.kt
@@ -2,6 +2,7 @@ package com.minturtle.cs.problem1
 
 import com.minturtle.cs.problem1.entity.Reservation
 import com.minturtle.cs.problem1.repository.ReservationRepository
+import com.minturtle.cs.problem1.service.ReservationCacheService
 import com.minturtle.cs.problem1.service.ReservationService
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -22,9 +23,14 @@ class ReservationServiceTest{
 
     @Autowired
     private lateinit var reservationRepository: ReservationRepository
+
+    @Autowired
+    private lateinit var cacheService: ReservationCacheService
+
     @BeforeEach
     fun setUp() {
         reservationRepository.deleteAll()
+        cacheService.clearAll()
     }
     @Test
     fun `Reservation 객체를 저장하고 조회할 수 있다`(){
@@ -96,6 +102,7 @@ class ReservationServiceTest{
         reservationService.toPermanent(reservation)
 
         assertThat(reservationRepository.findAll()).contains(reservation)
+        assertThat(cacheService.getAll()).doesNotContain(reservation)
     }
 
 

--- a/src/test/kotlin/com/minturtle/cs/problem1/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/minturtle/cs/problem1/ReservationServiceTest.kt
@@ -39,10 +39,10 @@ class ReservationServiceTest{
         reservationService.save(entity)
 
 
-        val actual = reservationService.findById(id)
+        val actual = reservationService.findAll()
 
         assertThat(actual).extracting( "dateId", "seatId")
-            .containsExactly( dateId, seatId)
+            .containsExactly( tuple(dateId, seatId))
     }
 
 

--- a/src/test/kotlin/com/minturtle/cs/service/problem1/ReservationServiceTest.kt
+++ b/src/test/kotlin/com/minturtle/cs/service/problem1/ReservationServiceTest.kt
@@ -1,6 +1,7 @@
 package com.minturtle.cs.service.problem1
 
 import com.minturtle.cs.problem1.entity.Reservation
+import com.minturtle.cs.problem1.repository.ReservationRepository
 import com.minturtle.cs.problem1.service.ReservationService
 import org.junit.jupiter.api.Test
 import org.springframework.boot.test.context.SpringBootTest
@@ -17,6 +18,10 @@ class ReservationServiceTest{
 
     @Autowired
     private lateinit var reservationService: ReservationService
+
+    @Autowired
+    private lateinit var reservationRepository: ReservationRepository
+
 
 
     @Test
@@ -78,6 +83,17 @@ class ReservationServiceTest{
         assertThat(failedCount.get()).isEqualTo(threadSize - reservationLists.size)
 
         assertThat(reservationService.findAll()).containsExactlyInAnyOrderElementsOf(reservationLists)
+    }
+
+    @Test
+    fun `캐시에 저장된 Reservation 객체를 DB에 저장할 수 있다`(){
+        val reservation = Reservation(1L, 2L)
+
+        reservationService.save(reservation)
+
+        reservationService.toPermanent(reservation)
+
+        assertThat(reservationRepository.findAll()).contains(reservation)
     }
 
 


### PR DESCRIPTION
### 개요
- DB에 저장하기 전에 캐시에 먼저 저장해 두었다가, 추후에 영속화 하는 로직으로 문제를 해결하였습니다.

### 상세
1. 저장하는 로직
- 먼저 DB에서 영속화된 엔티티가 있는지 조회한 후, 없으면 캐시에 저장을 시도합니다. 만약 캐시에 이미 값이 존재하거나 영속화된 엔티티가 존재한다면 throw합니다.
```kotlin
    fun save(entity: Reservation){
        val key = RESERVATION_CACHE_PREFIX + entity.hashCode()

        if (reservationRepository.findAll().contains(entity)){
            throw RuntimeException()
        }
        if(cache.add(key, entity)){
            return
        }
        throw RuntimeException()
    }

```
2. 조회하는 로직
- 엔티티들을 조회할 시에는 캐시에 존재하는 Entity와 영속화된 Entity를 모두 조회해야 했습니다. 따라서 아래와 같이 + 연산을 사용해 모두 검색하도록 하였습니다.
```kotlin
    fun findAll(): Collection<Reservation> {
        return reservationRepository.findAll() + cache.getAll()
    }
```
