### PR TITLE
문제 1: 동시 예약 문제 해결하기

### DIFF
--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationCacheService.kt
@@ -1,0 +1,32 @@
+package com.minturtle.cs.problem1.service
+
+import com.minturtle.cs.problem1.entity.Reservation
+import org.springframework.stereotype.Component
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.TemporalAmount
+import java.util.concurrent.ConcurrentHashMap
+
+@Component
+class ReservationCacheService {
+
+    private val cache: MutableMap<String, Pair<LocalDateTime, Reservation>> = ConcurrentHashMap()
+
+    fun get(key: String): Reservation?{
+        if(cache[key]?.first?.isBefore(LocalDateTime.now()) == true){
+            cache.remove(key)
+            return null
+        }
+        return cache[key]?.second
+    }
+
+    fun add(
+        key: String,
+        value: Reservation,
+        ttl: TemporalAmount = Duration.ofHours(1),
+        startAt: LocalDateTime = LocalDateTime.now()
+    ) : Boolean{
+        val pair = Pair(startAt.plus(ttl), value)
+        return cache.putIfAbsent(key, pair)?.let { return false } ?: true
+    }
+}

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -1,6 +1,7 @@
 package com.minturtle.cs.problem1.service
 
 import com.minturtle.cs.problem1.entity.Reservation
+import com.minturtle.cs.problem1.exception.MyDataIntegrationException
 import com.minturtle.cs.problem1.repository.ReservationRepository
 import org.springframework.stereotype.Service
 import java.lang.RuntimeException
@@ -9,22 +10,52 @@ import java.util.concurrent.atomic.AtomicInteger
 
 @Service
 class ReservationService(
-    private val reservationRepository: ReservationRepository
+    private val reservationRepository: ReservationRepository,
+    private val cacheManager: ReservationCacheService
 ) {
 
-    private val idSeq = AtomicInteger(0)
-
     fun save(dateId : Long, seatId: Long){
-        val newEntity = Reservation(idSeq.incrementAndGet().toString(), dateId, seatId)
+        val id = createReservationId(dateId, seatId)
 
-        reservationRepository.save(newEntity)
+        if(findById(id) != null){
+            throw RuntimeException()
+        }
+
+        val newEntity = Reservation(
+            id,
+            dateId,
+            seatId
+        )
+
+        try{
+            reservationRepository.save(newEntity)
+        }catch (e: MyDataIntegrationException){
+            throw RuntimeException()
+        }
+
     }
 
-    fun findById(id : String): Reservation {
-        return reservationRepository.findById(id) ?: throw RuntimeException()
+    fun findById(id : String): Reservation? {
+        var tmp = cacheManager.get(id)
+
+        if(tmp != null){
+            return tmp
+        }
+
+        tmp = reservationRepository.findById(id)
+        if(tmp != null){
+            cacheManager.add(id, tmp)
+            return tmp
+        }
+
+        return null
     }
 
     fun findAll(): Collection<Reservation> {
         return reservationRepository.findAll()
+    }
+
+    private fun createReservationId(dateId : Long, seatId: Long): String{
+        return "RESERVATION_${dateId}_${seatId}"
     }
 }

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -28,6 +28,7 @@ class ReservationService(
         )
 
         try{
+            cacheManager.add(newEntity.id, newEntity)
             reservationRepository.save(newEntity)
         }catch (e: MyDataIntegrationException){
             throw RuntimeException()

--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -28,8 +28,8 @@ class ReservationService(
         )
 
         try{
-            cacheManager.add(newEntity.id, newEntity)
             reservationRepository.save(newEntity)
+            cacheManager.add(newEntity.id, newEntity)
         }catch (e: MyDataIntegrationException){
             throw RuntimeException()
         }

--- a/src/test/kotlin/com/minturtle/cs/problem1/service/ReservationCacheServiceTest.kt
+++ b/src/test/kotlin/com/minturtle/cs/problem1/service/ReservationCacheServiceTest.kt
@@ -1,0 +1,86 @@
+package com.minturtle.cs.problem1.service
+
+import com.minturtle.cs.problem1.entity.Reservation
+import org.assertj.core.api.Assertions.*
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.params.ParameterizedTest
+import org.junit.jupiter.params.provider.Arguments
+import org.junit.jupiter.params.provider.MethodSource
+import java.time.Duration
+import java.time.LocalDateTime
+import java.time.temporal.TemporalAmount
+import java.util.stream.Stream
+import javax.xml.transform.stream.StreamResult
+
+class ReservationCacheServiceTest{
+
+    private val reservationCacheService = ReservationCacheService()
+
+
+    @Test
+    fun `캐시를 저장하고 조회할 수 있다`(){
+        val reservation = Reservation("id", 1L, 2L)
+
+        reservationCacheService.add(
+            reservation.id,
+            reservation
+        )
+
+        assertThat(reservationCacheService.get(reservation.id))
+            .isEqualTo(reservation)
+    }
+
+    @Test
+    fun `캐시의 ttl이 만료된 경우 null을 리턴한다`(){
+        val reservation = Reservation("id", 1L, 2L)
+
+        val startTime = LocalDateTime.MIN
+
+        reservationCacheService.add(
+            reservation.id,
+            reservation,
+            startAt = startTime
+        )
+
+        assertThat(reservationCacheService.get(reservation.id))
+            .isNull()
+
+    }
+
+    @ParameterizedTest
+    @MethodSource("getTTLAndExpectedResult")
+    fun `캐시의 TTL을 설정할 수 있다`(ttl: TemporalAmount, expected: Boolean){
+        val reservation = Reservation("id", 1L, 2L)
+
+        val addDateTime = LocalDateTime.now().minus(Duration.ofMinutes(30))
+
+        reservationCacheService.add(
+            reservation.id,
+            reservation,
+            ttl,
+            addDateTime
+        )
+
+        if(expected){
+            assertThat(reservationCacheService.get(reservation.id)).isNotNull()
+            return
+        }
+
+        assertThat(reservationCacheService.get(reservation.id)).isNull()
+
+
+
+    }
+
+    companion object{
+        @JvmStatic
+        private fun getTTLAndExpectedResult(): Stream<Arguments> {
+            return Stream.of(
+                Arguments.arguments(Duration.ofMinutes(1), false),
+                Arguments.arguments(Duration.ofHours(1), true),
+                Arguments.arguments(Duration.ofDays(1), true),
+            )
+        }
+    }
+
+}


### PR DESCRIPTION
### 문제 해결법
- DB의 Unique한 ID의 생성 전략을 변경하여 문제 해결 + 성능 향상을 위한 캐시 사용

### 상세
- 먼저 중복된 예약의 동시성 문제를 해결하기 위해선, 어떤게 중복된 것인지, 즉 예약 객체의 동등성을 정의해주어야 할 필요가 있습니다.
- 예약은 두개의 필드(공연 날짜, 좌석 정보)가 존재하며, 이 두개의 필드가 같다면 동등하다고 생각하였습니다.
- 따라서 먼저 ID의 생성 전략을 두개의 필드를 기반으로 생성하여. 두개의 필드가 같다면 같은 ID를 갖도록 설계하였습니다.
````kotlin
    private fun createReservationId(dateId : Long, seatId: Long): String{
        return "RESERVATION_${dateId}_${seatId}"
    }
````
- 이렇게 동등한 객체가 같은 ID를 사용하게 된다면, DB 차원에서 저장을 시도할 시 `DataIntegrityViolationException`이 발생하는 것을 유도할 수 있습니다.
```kotlin
try{
    reservationRepository.save(newEntity)
}catch (e: MyDataIntegrationException){
    throw RuntimeException()
}
```
- 이 코드 만으로도 테스트는 통과가 가능하였지만, 예약 시스템의 특성상 비슷한 요청이 순간적으로 몰릴수 있기 때문에 캐시를 적용하기 적합한 상황이라고 판단하였습니다.
- 따라서 캐시를 도입하기로 결정하고, 캐시 전략은 Look Aside + Write Through를 사용하여 구현하였습니다.

**읽기 전략 : Look Aside 코드**
```kotlin
    fun findById(id : String): Reservation? {
        var tmp = cacheManager.get(id)

        if(tmp != null){
            return tmp
        }

        tmp = reservationRepository.findById(id)
        if(tmp != null){
            cacheManager.add(id, tmp)
            return tmp
        }

        return null
    }
```
- Look Aside 전략은 먼저 캐시에서 데이터를 조회하고, 캐시미스 발생시 DB에서 데이터를 조회해 캐시에 올리는 방법입니다.

**쓰기 전략: Write Through 전략**
```kotlin
val newEntity = Reservation(
    id,
    dateId,
    seatId
)

try{
    reservationRepository.save(newEntity)
    cacheManager.add(newEntity.id, newEntity)
}catch (e: MyDataIntegrationException){
    throw RuntimeException()
}
```
- 쓰기 전략은 DB와 캐시 모두에 업로드하는 방식입니다. 앞서 언급한대로 예약 서비스는 캐시 히트율이 높을 것으로 판단되기 때문에 비용이 조금 비싸더라도 Write Through 방식을 도입하였습니다.


