### PR TITLE
문제 1: 동시 예약 문제 해결하기- 문제 해결

### DIFF
--- a/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem1/service/ReservationService.kt
@@ -3,25 +3,42 @@ package com.minturtle.cs.problem1.service
 import com.minturtle.cs.problem1.entity.Reservation
 import com.minturtle.cs.problem1.repository.ReservationRepository
 import org.springframework.stereotype.Service
-import java.lang.RuntimeException
+import java.util.concurrent.ConcurrentHashMap
 import java.util.concurrent.atomic.AtomicInteger
-
+import kotlin.RuntimeException
 
 @Service
 class ReservationService(
     private val reservationRepository: ReservationRepository
 ) {
-
     private val idSeq = AtomicInteger(0)
+    private val reservationTable : MutableMap<String, Boolean> = ConcurrentHashMap()
 
     fun save(dateId : Long, seatId: Long){
-        val newEntity = Reservation(idSeq.incrementAndGet().toString(), dateId, seatId)
+        val id = "$dateId.$seatId"
+        val newEntity = Reservation(id, dateId, seatId)
 
-        reservationRepository.save(newEntity)
+        if (reservationTable.putIfAbsent(id, true) == null) {
+            findAndSave(newEntity)
+
+            return
+        }
+
+        throw RuntimeException()
     }
 
-    fun findById(id : String): Reservation {
-        return reservationRepository.findById(id) ?: throw RuntimeException()
+    @Synchronized fun findAndSave(entity: Reservation) {
+        if (findById(entity.id) == null) {
+            reservationRepository.save(entity)
+
+            return
+        }
+
+        throw RuntimeException("이미 예약된 좌석입니다");
+    }
+
+    fun findById(id: String): Reservation? {
+        return reservationRepository.findById(id)
     }
 
     fun findAll(): Collection<Reservation> {


### PR DESCRIPTION
## 문제 해결법1: pk로 제약조건 걸기

Reservation이 이미 있는지 확인을 위해 primaryKey를 dateId와 seatId를 조합한 값으로 지정해주면 된다. 한 date당 한 자리만 예약가능하기 때문에 중복값은 절대 나오지 않는다. 중복값이 존재한다면 엔티티를 저장하는 과정에서 exception을 던지는 식으로 처리하면 된다.

<br/>

## 문제 해결법2: 연산 원자적으로 묶기

간단하게 생각하면, save과정에서 
(1)해당 엔티티 조회하기 
(2)해당 엔티티가 없다면 저장하기 
두 과정을 원자적으로 수행하면 문제를 해결할 수 있다. 그래서 @Synchronized 로 두 로직을 메서드로 묶고, 한 스레드만 실행가능하도록 만들어줬다.


```kotlin
fun save(dateId : Long, seatId: Long){
    val newEntity = Reservation("$dateId.$seatId", dateId, seatId)

    findAndSave(newEntity)
}

@Synchronized fun findAndSave(entity: Reservation) {
    if (findById(entity.id) == null) {
        reservationRepository.save(entity)

        return
    }

    throw RuntimeException("이미 예약된 좌석입니다");
}
```

(물론 1번 방법으로 충분히 처리가 가능하기 때문에 굳이 Synchronized 키워드를 쓰지 않아도 된다. 하지만 pk로 처리할 수 없고 service로만 처리해야한다면 이 방법밖에 없는 것 같다)

<br/>

## 문제 해결법3: ConcurrentHashMap에 저장하기

디비 조회는 시간이 많이 걸리는 작업이기 때문에(실제로 sleep이 걸려있는 걸 볼 수 있음) 성능을 개선하고자 ConcurrentHashMap을 도입하여 캐싱의 효과를 내보려고 했다.

```kotlin
fun save(dateId : Long, seatId: Long){
    val id = "$dateId.$seatId"
    val newEntity = Reservation(id, dateId, seatId)

		//확인과 put이 원자적으로 동작
    if (reservationTable.putIfAbsent(id, true) == null) {
        findAndSave(newEntity)

        return
    }

    throw RuntimeException()
}

fun findAndSave(entity: Reservation) {
    if (findById(entity.id) == null) {
        reservationRepository.save(entity)

        return
    }

    throw RuntimeException("이미 예약된 좌석입니다");
}
```

유일한 값인 id를 key값으로 ConcurrentHashMap에 저장했다. 이렇게 하니 디비 조회 횟수가 줄어들어 시간이 짧아진 걸 확인할 수 있었다.


![image](https://github.com/user-attachments/assets/009f60fc-8327-49de-ae0a-81c6b6fcb03b)


![image](https://github.com/user-attachments/assets/664d467d-d35a-46f3-90fa-932d22a52552)


