### PR TITLE
문제2 : 계좌의 동시접근 문제 해결하기- 문제 해결

### DIFF
--- a/src/main/kotlin/com/minturtle/cs/problem2/service/AccountService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem2/service/AccountService.kt
@@ -4,7 +4,6 @@ import com.minturtle.cs.problem2.entity.Account
 import com.minturtle.cs.problem2.repository.AccountRepository
 import org.springframework.stereotype.Service
 import java.lang.RuntimeException
-import java.util.concurrent.atomic.AtomicInteger
 
 
 @Service
@@ -16,9 +15,16 @@ class AccountService(
     }
 
     fun deposit(id: Long, amount: Int){
+        val lock = Problem2LockService.acquire(id)
+
+        while(!lock.tryLock()){
+
+        }
+
         val account = findById(id)
 
         account.deposit(amount)
+        lock.unlock()
     }
 
     fun findById(id : Long): Account {

--- a/src/main/kotlin/com/minturtle/cs/problem2/service/AccountService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem2/service/AccountService.kt
@@ -17,9 +17,7 @@ class AccountService(
     fun deposit(id: Long, amount: Int){
         val lock = Problem2LockService.acquire(id)
 
-        while(!lock.tryLock()){
-
-        }
+        lock.lock()
 
         val account = findById(id)
 

--- a/src/main/kotlin/com/minturtle/cs/problem2/service/Problem2LockService.kt
+++ b/src/main/kotlin/com/minturtle/cs/problem2/service/Problem2LockService.kt
@@ -1,0 +1,17 @@
+package com.minturtle.cs.problem2.service
+
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.locks.ReentrantLock
+
+
+object Problem2LockService {
+
+    private val locks : MutableMap<Long, ReentrantLock> = ConcurrentHashMap()
+
+    fun acquire(key: Long): ReentrantLock{
+        val lock = ReentrantLock(true)
+
+        return locks.putIfAbsent(key, lock) ?: lock
+    }
+
+}


### PR DESCRIPTION
### 문제 해결법
- Lock을 사용하여 하나의 계좌에 하나의 스레드만 접근이 가능하도록 제한하여 문제 해결

### 상세
- Concurrent HashMap에 ReentrantLock를 사용하여 계좌의 id로 락을 얻은 다음, lock을 걸고 계좌에 deposit을 진행합니다.
- 처음에는 spin Lock을 사용하여 락을 구현하였는데, 성능을 비교해 보니 ReentrantLock를 사용한 블로킹 락이 훨씬 성능이 좋은 것을 확인 할 수 있었습니다.(Spin Lock : 약 10초, ReetrantLock : 약 2초)
- spin lock acquire 코드
```kotlin
while(!lock.tryLock()){

}
```

- blocking lock acquire 코드
```kotlin
lock.lock()
```



- 만약 어플리케이션 서버가 여러대라면, Redis + Lectture 라이브러리를 사용하여 Blocking 분산 락을 구현할 수 있습니다.
